### PR TITLE
Fix error in endpoint URL when doing an attribute patch

### DIFF
--- a/src/Akeneo/Common/EndpointResolver.cs
+++ b/src/Akeneo/Common/EndpointResolver.cs
@@ -49,7 +49,7 @@ namespace Akeneo.Common
 			var option = existing as AttributeOption;
 			if (option != null)
 			{
-				return $"{baseUri}/{option.Attribute}/option/{option.Code}";
+				return $"{baseUri}/{option.Attribute}/options/{option.Code}";
 			}
 			var family = existing as Family;
 			if (family != null)


### PR DESCRIPTION
Current implentation was causing route not found on akeneo

fixed according to documentation :
https://api.akeneo.com/api-reference.html#patch_attributes__attribute_code__options__code_